### PR TITLE
Controls

### DIFF
--- a/ai/tasks/a_actions_gj/melee_attack.gd
+++ b/ai/tasks/a_actions_gj/melee_attack.gd
@@ -6,6 +6,5 @@ func _tick(_delta: float) -> Status:
 	(agent as FirstBoss).bury()	
 	if((agent as FirstBoss).melee_attack((blackboard.get_data().get("player") as PlayerCharacter).global_position)):
 		blackboard.set_var("remaining_melee_attacks",(blackboard.get_data().get("remaining_melee_attacks") as int) - 1)
-		print("Remaining melee attacks: ",blackboard.get_data().get("remaining_melee_attacks") as int)
 		return SUCCESS
 	return FAILURE

--- a/ai/tasks/a_actions_gj/range_attack.gd
+++ b/ai/tasks/a_actions_gj/range_attack.gd
@@ -4,6 +4,5 @@ extends BTAction
 func _tick(_delta: float) -> Status:
 	if((agent as FirstBoss).range_attack((blackboard.get_data().get("player") as CharacterBody2D).global_position)):
 		blackboard.set_var("remaining_range_attacks",(blackboard.get_data().get("remaining_range_attacks") as int) - 1)
-		print("Remaining range attacks: ",blackboard.get_data().get("remaining_range_attacks") as int)
 		return SUCCESS
 	return FAILURE

--- a/assets/graphic/ui/dialogues.tres
+++ b/assets/graphic/ui/dialogues.tres
@@ -26,6 +26,8 @@ texture_margin_right = 20.0
 texture_margin_bottom = 20.0
 
 [resource]
+Button/styles/focus = SubResource("StyleBoxTexture_iljgh")
+Button/styles/hover = SubResource("StyleBoxTexture_iljgh")
 Button/styles/normal = SubResource("StyleBoxTexture_iljgh")
 Button/styles/pressed = SubResource("StyleBoxTexture_6hscs")
 Panel/styles/panel = SubResource("StyleBoxTexture_nc4p7")

--- a/assets/graphic/ui/ui.tres
+++ b/assets/graphic/ui/ui.tres
@@ -1,8 +1,8 @@
 [gd_resource type="Theme" load_steps=11 format=3 uid="uid://cvcuf7q8qqwyk"]
 
-[ext_resource type="Texture2D" uid="uid://o66w4pg2tp3g" path="res://assets/graphic/ui/SliderGrabber.png" id="1_ebpvj"]
-[ext_resource type="Texture2D" uid="uid://b3lbejncsrb3o" path="res://assets/graphic/ui/SoundBarFilled.png" id="2_ydofy"]
-[ext_resource type="Texture2D" uid="uid://pekyccqwkatr" path="res://assets/graphic/ui/SoundBar.png" id="3_db10c"]
+[ext_resource type="Texture2D" uid="uid://b3vyry1sphgh8" path="res://assets/graphic/ui/SliderGrabber.png" id="1_ebpvj"]
+[ext_resource type="Texture2D" uid="uid://21pkwayckbta" path="res://assets/graphic/ui/SoundBarFilled.png" id="2_ydofy"]
+[ext_resource type="Texture2D" uid="uid://c5k3h0jmeq5jb" path="res://assets/graphic/ui/SoundBar.png" id="3_db10c"]
 [ext_resource type="FontFile" uid="uid://b7k3h0gpoesni" path="res://assets/graphic/font/ComicNeue-Regular.ttf" id="4_u5yq3"]
 [ext_resource type="Texture2D" uid="uid://djnvmxngcsr48" path="res://assets/graphic/ui/SpecialBar.png" id="5_r5frn"]
 

--- a/dialogues/meeting_the_magic_helm.dialogue
+++ b/dialogues/meeting_the_magic_helm.dialogue
@@ -45,8 +45,9 @@ Player: At least I GET ONE GOOD THING, even if its pointless..
 Helmet: .......
 Helmet: So do we have a deal?
 - Deal
-	set StoryState.agreed_with_the_helmet = true
+	set StoryState.is_player_has_dark_ability = true
+	do BossRushUtility.show_opened_abilities()
 - Never
-	set StoryState.agreed_with_the_helmet = false
+	set StoryState.is_player_has_dark_ability = false
 
 => END

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Boss Rush Gj 2024-abds"
-run/main_scene="res://scenes/levels/2_boss_fight/2_boss_fight.tscn"
+run/main_scene="res://scenes/levels/0_menu/0_menu.tscn"
 config/features=PackedStringArray("4.2", "GL Compatibility")
 config/icon="res://icon.svg"
 
@@ -22,6 +22,7 @@ DialogueManager="*res://addons/dialogue_manager/dialogue_manager.gd"
 TestStoryState="*res://_debug/test_roleplay_system/autoload/test_story_state.gd"
 StoryState="*res://scripts/autoload/story_state.gd"
 Settings="*res://scripts/autoload/settings.gd"
+BossRushUtility="*res://scripts/autoload/boss_rush_utility.gd"
 
 [debug]
 
@@ -42,6 +43,7 @@ general/balloon_path="res://scenes/dialogues_objects/balloon.tscn"
 
 window/size/viewport_width=1920
 window/size/viewport_height=1080
+window/size/mode=3
 window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
 

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Boss Rush Gj 2024-abds"
-run/main_scene="res://scenes/levels/0_menu/0_menu.tscn"
+run/main_scene="res://scenes/levels/2_boss_fight/2_boss_fight.tscn"
 config/features=PackedStringArray("4.2", "GL Compatibility")
 config/icon="res://icon.svg"
 
@@ -109,6 +109,35 @@ parry={
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"canceled":false,"pressed":false,"double_click":false,"script":null)
 ]
 }
+activate_dark_knight={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":101,"echo":false,"script":null)
+]
+}
+move_up={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+move_right={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194321,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"echo":false,"script":null)
+]
+}
+move_down={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194322,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+move_left={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194319,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
 
 [internationalization]
 
@@ -125,4 +154,3 @@ locale/translations_pot_files=PackedStringArray("res://_debug/test_roleplay_syst
 
 renderer/rendering_method="gl_compatibility"
 renderer/rendering_method.mobile="gl_compatibility"
-environment/defaults/default_clear_color=Color(0, 0, 0, 1)

--- a/scenes/dialogues_objects/balloon.tscn
+++ b/scenes/dialogues_objects/balloon.tscn
@@ -9,7 +9,6 @@
 [ext_resource type="AudioStream" uid="uid://cm3l52nktgnom" path="res://assets/audio/sfx/talking_effect_light.wav" id="7_sfnbj"]
 
 [node name="ExampleBalloon" type="CanvasLayer"]
-process_mode = 3
 layer = 100
 script = ExtResource("1_4u26j")
 
@@ -95,10 +94,12 @@ layout_mode = 2
 text = "Response example"
 
 [node name="BadGuySound" type="AudioStreamPlayer" parent="."]
+unique_name_in_owner = true
 stream = ExtResource("6_vfngv")
 bus = &"SFX"
 
 [node name="GoodGuySound" type="AudioStreamPlayer" parent="."]
+unique_name_in_owner = true
 stream = ExtResource("7_sfnbj")
 bus = &"SFX"
 

--- a/scenes/enemies/bosses/first_boss/first_boss.tscn
+++ b/scenes/enemies/bosses/first_boss/first_boss.tscn
@@ -9,7 +9,7 @@
 [ext_resource type="BehaviorTree" uid="uid://c2yud3vequuq1" path="res://ai/trees/first_boss.tres" id="5_lw0bb"]
 [ext_resource type="PackedScene" uid="uid://ig227kj7uunu" path="res://scenes/enemies/bosses/first_boss/range_attack/range_attacks_spawner.tscn" id="6_o3887"]
 [ext_resource type="Script" path="res://scenes/enemies/bosses/first_boss/boss_hud.gd" id="9_0w47o"]
-[ext_resource type="Texture2D" uid="uid://cumdmfjxndqk0" path="res://assets/graphic/ui/BossHP.png" id="10_ap4vv"]
+[ext_resource type="Texture2D" uid="uid://bo6jv1ga7rwx" path="res://assets/graphic/ui/BossHP.png" id="10_ap4vv"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_msbcd"]
 size = Vector2(84, 80)
@@ -651,6 +651,7 @@ position = Vector2(4, -106)
 
 [node name="FirstBossBehaviorTree" type="BTPlayer" parent="."]
 behavior_tree = ExtResource("5_lw0bb")
+unique_name_in_owner = true
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {

--- a/scenes/enemies/bosses/first_boss/powerful_attack/powerful_spikes_spawner.gd
+++ b/scenes/enemies/bosses/first_boss/powerful_attack/powerful_spikes_spawner.gd
@@ -12,9 +12,6 @@ var _finished: bool = false
 func _ready() -> void:
 	if _attack_duration.timeout.connect(_on_powerful_attack_finished):printerr("Fail: ",get_stack()) 
 
-func _process(delta: float) -> void:
-	print(_attack_duration.time_left)
-
 func attack(position_to_attack: Vector2, duration_of_attack: float = 8.0,attack_cooldown:float = 0.9)->void:
 	attack_handle(duration_of_attack)
 	if(_spikes_pool.size()<3 and _attack_cooldown.is_stopped()):

--- a/scenes/levels/0_menu/0_menu.gd
+++ b/scenes/levels/0_menu/0_menu.gd
@@ -1,10 +1,25 @@
 extends Node
 
-@onready var play_button: Button = $CanvasLayer/Wrapper/PlayButton
-
+@onready var _play_button: Button = %PlayButton
+@onready var _controls_button: Button = %ControlsWindowButton
+@onready var _exit_button: Button =  %Exit
+@onready var _controls_pc: PackedScene = preload("res://scenes/ui/controls_window.tscn")
 
 func _ready() -> void:
-	if play_button.connect("pressed", _on_pressed_play_button): printerr("Fail: ",get_stack()) 
+	if _play_button.connect("pressed", _on_pressed_play_button): printerr("Fail: ",get_stack()) 
+	if _controls_button.connect("pressed", _on_pressed_controls_window_button): printerr("Fail: ",get_stack()) 
+	if _exit_button.pressed.connect(_on_exit_pressed): printerr("Fail: ",get_stack())
 
 func _on_pressed_play_button()->void:
+	BossRushUtility.play_click_sound()
 	LevelManager.load_level("res://scenes/levels/1_prologue/1_prologue.tscn")
+
+func _on_pressed_controls_window_button()->void:
+	BossRushUtility.play_click_sound()
+	var controls_window: CanvasItem = _controls_pc.instantiate() as CanvasItem
+	controls_window.z_index = 2
+	$CanvasLayer.add_child(controls_window)
+
+func _on_exit_pressed()->void:
+	BossRushUtility.play_click_sound()
+	get_tree().quit()

--- a/scenes/levels/0_menu/0_menu.tscn
+++ b/scenes/levels/0_menu/0_menu.tscn
@@ -1,26 +1,50 @@
-[gd_scene load_steps=6 format=3 uid="uid://jmd4bkjhu5w5"]
+[gd_scene load_steps=11 format=3 uid="uid://jmd4bkjhu5w5"]
 
 [ext_resource type="Script" path="res://scenes/levels/0_menu/0_menu.gd" id="1_d03u3"]
 [ext_resource type="Texture2D" uid="uid://dlaghxs0rehfb" path="res://assets/graphic/ui/PlayButton_pressed.png" id="2_q5v5a"]
 [ext_resource type="Texture2D" uid="uid://cl6b400nytsio" path="res://assets/graphic/ui/PlayButton.png" id="3_14c0d"]
+[ext_resource type="FontFile" uid="uid://beo8lmqouqh0k" path="res://assets/graphic/font/ComicNeue-Bold.ttf" id="3_ockyh"]
 [ext_resource type="PackedScene" uid="uid://cl6ujwlw4p48c" path="res://scenes/ui/sound_settings.tscn" id="4_y7slp"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_pif12"]
+bg_color = Color(0.121569, 0.619608, 0.254902, 1)
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color(0.921569, 0.913725, 0.913725, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_w80sp"]
+bg_color = Color(0.121569, 0.619608, 0.254902, 1)
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color(0.921569, 0.913725, 0.913725, 1)
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_1wgnb"]
 texture = ExtResource("2_q5v5a")
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1ef0x"]
+bg_color = Color(0.121569, 0.619608, 0.254902, 1)
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color(0.921569, 0.913725, 0.913725, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_j78u8"]
+bg_color = Color(0.121569, 0.619608, 0.254902, 1)
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color(0.921569, 0.913725, 0.913725, 1)
 
 [node name="Menu" type="Node"]
 script = ExtResource("1_d03u3")
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
-
-[node name="SoundSettings" parent="CanvasLayer" instance=ExtResource("4_y7slp")]
-anchors_preset = -1
-anchor_left = 0.003
-offset_left = 9.24
-offset_top = 14.0
-offset_right = -426.0
-offset_bottom = -343.0
-scale = Vector2(0.71, 0.71)
 
 [node name="Wrapper" type="Control" parent="CanvasLayer"]
 layout_mode = 3
@@ -30,7 +54,42 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
+[node name="SoundSettings" parent="CanvasLayer/Wrapper" instance=ExtResource("4_y7slp")]
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.003
+offset_left = 9.24
+offset_top = 14.0
+offset_right = -426.0
+offset_bottom = -343.0
+scale = Vector2(0.71, 0.71)
+
+[node name="ControlsWindowButton" type="Button" parent="CanvasLayer/Wrapper"]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -41.5
+offset_top = -257.0
+offset_right = 127.5
+offset_bottom = -194.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_fonts/font = ExtResource("3_ockyh")
+theme_override_font_sizes/font_size = 40
+theme_override_styles/normal = SubResource("StyleBoxFlat_pif12")
+theme_override_styles/hover = SubResource("StyleBoxFlat_pif12")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_w80sp")
+keep_pressed_outside = true
+text = "Controls"
+expand_icon = true
+
 [node name="PlayButton" type="Button" parent="CanvasLayer/Wrapper"]
+unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
@@ -50,3 +109,18 @@ keep_pressed_outside = true
 icon = ExtResource("3_14c0d")
 flat = true
 expand_icon = true
+
+[node name="Exit" type="Button" parent="CanvasLayer/Wrapper"]
+unique_name_in_owner = true
+offset_left = 964.0
+offset_top = 670.0
+offset_right = 1043.0
+offset_bottom = 733.0
+size_flags_horizontal = 4
+size_flags_vertical = 6
+theme_override_fonts/font = ExtResource("3_ockyh")
+theme_override_font_sizes/font_size = 40
+theme_override_styles/normal = SubResource("StyleBoxFlat_1ef0x")
+theme_override_styles/hover = SubResource("StyleBoxFlat_1ef0x")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_j78u8")
+text = "Exit"

--- a/scenes/levels/2_boss_fight/2_boss_fight.gd
+++ b/scenes/levels/2_boss_fight/2_boss_fight.gd
@@ -1,13 +1,53 @@
 extends Node
 
-var pause_screen_pc: PackedScene = preload("res://scenes/ui/pause_hud.tscn")
+@onready var _pause_screen_pc: PackedScene = preload("res://scenes/ui/pause_hud.tscn")
+@onready var _music: AudioStreamPlayer2D = %AudioStreamPlayer2D
 
 func _ready() -> void:
+	get_tree().paused = true
 	await LevelManager.transition_finished
+	_hide_ui()
+	get_tree().paused = false
 	@warning_ignore("return_value_discarded")
 	DialogueManager.show_dialogue_balloon(load("res://dialogues/pre_boss.dialogue") as DialogueResource)
+	if DialogueManager.dialogue_ended.connect(_on_entry_dialogue_finished): printerr("Fail: ",get_stack())
 
 func _physics_process(_delta: float) -> void:
 	if Input.is_key_pressed(KEY_ESCAPE):
-		var pause_screen: CanvasLayer =  pause_screen_pc.instantiate()
-		get_tree().current_scene.add_child(pause_screen)
+		var _pause_screen: CanvasLayer =  _pause_screen_pc.instantiate()
+		get_tree().current_scene.add_child(_pause_screen)
+
+func _hide_ui()->void:
+	var player_ui: CanvasLayer
+	var boss_ui: CanvasLayer
+	for node: Node in get_tree().current_scene.get_children():
+		if(node is PlayerCharacter):
+			for canvas: Node in node.get_children():
+				if(canvas is CanvasLayer):
+					player_ui = canvas
+		elif(node is FirstBoss):
+			for canvas: Node in node.get_children():
+				if(canvas is CanvasLayer):
+					boss_ui = canvas
+	player_ui.hide()
+	boss_ui.hide()
+
+func _show_ui()->void:
+	var player_ui: CanvasLayer
+	var boss_ui: CanvasLayer
+	for node: Node in get_tree().current_scene.get_children():
+		if(node is PlayerCharacter):
+			for canvas: Node in node.get_children():
+				if(canvas is CanvasLayer):
+					player_ui = canvas
+		elif(node is FirstBoss):
+			for canvas: Node in node.get_children():
+				if(canvas is CanvasLayer):
+					boss_ui = canvas
+	player_ui.show()
+	boss_ui.show()
+
+func _on_entry_dialogue_finished(dialogue: DialogueResource)->void:
+	_music.play()
+	_show_ui()
+	DialogueManager.dialogue_ended.disconnect(_on_entry_dialogue_finished)

--- a/scenes/levels/2_boss_fight/2_boss_fight.tscn
+++ b/scenes/levels/2_boss_fight/2_boss_fight.tscn
@@ -109,8 +109,8 @@ scale = Vector2(14.988, 11.388)
 texture = ExtResource("8_oq80l")
 
 [node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="."]
+unique_name_in_owner = true
 stream = ExtResource("5_dmkg8")
-autoplay = true
 bus = &"Music"
 
 [node name="DirectionalLight2D" type="DirectionalLight2D" parent="."]

--- a/scenes/levels/3_magic_helmet/3_magic_helmet.gd
+++ b/scenes/levels/3_magic_helmet/3_magic_helmet.gd
@@ -1,0 +1,8 @@
+extends Node
+
+@onready var dialogue_with_magic_helmet: DialogueResource = preload("res://dialogues/meeting_the_magic_helm.dialogue")
+
+func _ready() -> void:
+	#await LevelManager.transition_finished
+	@warning_ignore("return_value_discarded")
+	DialogueManager.show_dialogue_balloon(dialogue_with_magic_helmet)

--- a/scenes/levels/3_magic_helmet/3_magic_helmet.tscn
+++ b/scenes/levels/3_magic_helmet/3_magic_helmet.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://cy78go6odhdn8"]
+
+[ext_resource type="Script" path="res://scenes/levels/3_magic_helmet/3_magic_helmet.gd" id="1_7wmwe"]
+
+[node name="3MagicHelmet" type="Node"]
+script = ExtResource("1_7wmwe")

--- a/scenes/ui/controls_window.gd
+++ b/scenes/ui/controls_window.gd
@@ -1,26 +1,25 @@
-extends MarginContainer
+class_name ControlsWindow
+extends PanelContainer
 
-@onready var _blur_dark_controls: Panel = %BlurDarkControls
+@onready var _hide_dark_controls: Panel = %HideDarkControls
 @onready var _timer: Timer = Timer.new()
 @onready var _close_button: Button = %Close
-var _start_animation: bool = false
-
-func _init(start_animation: bool = false) -> void:
-	_start_animation = start_animation
+var start_animation: bool = false
 	
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	if _close_button.pressed.connect(_on_closed): printerr("Fail: ",get_stack())
-	if(_start_animation == true):
+	if(start_animation == true):
 		add_child(_timer)
 		_timer.one_shot = true
 		_timer.start(1.0)
 	if(StoryState.is_player_has_dark_ability == true):
-		_blur_dark_controls.material["shader_parameter/lod"] = 0
+		(_hide_dark_controls.get_theme_stylebox("panel","Panel") as StyleBoxFlat).bg_color = Color(0,0,0,1.0)
 
 func _process(delta: float) -> void:
-	if(_start_animation == true):
-		_blur_dark_controls.material["shader_parameter/lod"] = lerpf(0,5.0,_timer.time_left)
+	if(start_animation == true):
+		(_hide_dark_controls.get_theme_stylebox("panel","Panel") as StyleBoxFlat).bg_color.a = lerpf(0,1.0,_timer.time_left)
 
 func _on_closed()->void:
+	BossRushUtility.play_click_sound()
 	queue_free()

--- a/scenes/ui/controls_window.gd
+++ b/scenes/ui/controls_window.gd
@@ -1,0 +1,26 @@
+extends MarginContainer
+
+@onready var _blur_dark_controls: Panel = %BlurDarkControls
+@onready var _timer: Timer = Timer.new()
+@onready var _close_button: Button = %Close
+var _start_animation: bool = false
+
+func _init(start_animation: bool = false) -> void:
+	_start_animation = start_animation
+	
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	if _close_button.pressed.connect(_on_closed): printerr("Fail: ",get_stack())
+	if(_start_animation == true):
+		add_child(_timer)
+		_timer.one_shot = true
+		_timer.start(1.0)
+	if(StoryState.is_player_has_dark_ability == true):
+		_blur_dark_controls.material["shader_parameter/lod"] = 0
+
+func _process(delta: float) -> void:
+	if(_start_animation == true):
+		_blur_dark_controls.material["shader_parameter/lod"] = lerpf(0,5.0,_timer.time_left)
+
+func _on_closed()->void:
+	queue_free()

--- a/scenes/ui/controls_window.tscn
+++ b/scenes/ui/controls_window.tscn
@@ -1,9 +1,11 @@
-[gd_scene load_steps=7 format=3 uid="uid://bgfrb27nvy1ug"]
+[gd_scene load_steps=9 format=3 uid="uid://bgfrb27nvy1ug"]
 
 [ext_resource type="Script" path="res://scenes/ui/controls_window.gd" id="1_6ds06"]
 [ext_resource type="FontFile" uid="uid://beo8lmqouqh0k" path="res://assets/graphic/font/ComicNeue-Bold.ttf" id="1_bv8wj"]
 [ext_resource type="Texture2D" uid="uid://cmq216oemk1ex" path="res://assets/graphic/ui/LightDialogueBox.png" id="2_w6cn0"]
-[ext_resource type="Shader" path="res://shaders/blur.gdshader" id="4_6bmxp"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_fdcsr"]
+bg_color = Color(0, 0, 0, 1)
 
 [sub_resource type="Theme" id="Theme_uaxhm"]
 Label/font_sizes/font_size = 16
@@ -11,38 +13,57 @@ Label/fonts/font = ExtResource("1_bv8wj")
 TextEdit/font_sizes/font_size = 18
 TextEdit/fonts/font = ExtResource("1_bv8wj")
 
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_h03g3"]
-shader = ExtResource("4_6bmxp")
-shader_parameter/lod = 5.0
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_6d1jf"]
+bg_color = Color(0, 0, 0, 1)
 
-[node name="OutMargin" type="MarginContainer"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_pif12"]
+bg_color = Color(0.121569, 0.619608, 0.254902, 1)
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color(0.921569, 0.913725, 0.913725, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_w80sp"]
+bg_color = Color(0.121569, 0.619608, 0.254902, 1)
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color(0.921569, 0.913725, 0.913725, 1)
+
+[node name="PanelContainer" type="PanelContainer"]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_fdcsr")
+script = ExtResource("1_6ds06")
+
+[node name="OutMargin" type="MarginContainer" parent="."]
+layout_mode = 2
 theme_override_constants/margin_left = 100
 theme_override_constants/margin_top = 100
 theme_override_constants/margin_right = 100
 theme_override_constants/margin_bottom = 100
-script = ExtResource("1_6ds06")
 
-[node name="InMargin" type="MarginContainer" parent="."]
+[node name="InMargin" type="MarginContainer" parent="OutMargin"]
 layout_mode = 2
 theme_override_constants/margin_left = 20
 theme_override_constants/margin_top = 20
 theme_override_constants/margin_right = 20
 theme_override_constants/margin_bottom = 20
 
-[node name="ControlsWindow" type="VBoxContainer" parent="InMargin"]
+[node name="ControlsWindow" type="VBoxContainer" parent="OutMargin/InMargin"]
 layout_mode = 2
 theme = SubResource("Theme_uaxhm")
 
-[node name="MoveUp" type="HBoxContainer" parent="InMargin/ControlsWindow"]
+[node name="MoveUp" type="HBoxContainer" parent="OutMargin/InMargin/ControlsWindow"]
 layout_mode = 2
 size_flags_horizontal = 4
 
-[node name="ButtonTexture" type="TextureRect" parent="InMargin/ControlsWindow/MoveUp"]
+[node name="ButtonTexture" type="TextureRect" parent="OutMargin/InMargin/ControlsWindow/MoveUp"]
 custom_minimum_size = Vector2(80, 80)
 layout_mode = 2
 size_flags_vertical = 4
@@ -50,7 +71,7 @@ size_flags_stretch_ratio = 0.0
 texture = ExtResource("2_w6cn0")
 expand_mode = 5
 
-[node name="ControlName" type="Label" parent="InMargin/ControlsWindow/MoveUp/ButtonTexture"]
+[node name="ControlName" type="Label" parent="OutMargin/InMargin/ControlsWindow/MoveUp/ButtonTexture"]
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
@@ -67,7 +88,7 @@ theme_override_font_sizes/font_size = 56
 text = "W"
 horizontal_alignment = 1
 
-[node name="Hyphen" type="Label" parent="InMargin/ControlsWindow/MoveUp"]
+[node name="Hyphen" type="Label" parent="OutMargin/InMargin/ControlsWindow/MoveUp"]
 custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 size_flags_horizontal = 4
@@ -75,17 +96,17 @@ theme_override_font_sizes/font_size = 56
 text = "-"
 horizontal_alignment = 1
 
-[node name="Description" type="Label" parent="InMargin/ControlsWindow/MoveUp"]
-custom_minimum_size = Vector2(400, 0)
+[node name="Description" type="Label" parent="OutMargin/InMargin/ControlsWindow/MoveUp"]
+custom_minimum_size = Vector2(600, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 36
 text = "Move UP"
 
-[node name="MoveDown" type="HBoxContainer" parent="InMargin/ControlsWindow"]
+[node name="MoveDown" type="HBoxContainer" parent="OutMargin/InMargin/ControlsWindow"]
 layout_mode = 2
 size_flags_horizontal = 4
 
-[node name="ButtonTexture" type="TextureRect" parent="InMargin/ControlsWindow/MoveDown"]
+[node name="ButtonTexture" type="TextureRect" parent="OutMargin/InMargin/ControlsWindow/MoveDown"]
 custom_minimum_size = Vector2(80, 80)
 layout_mode = 2
 size_flags_vertical = 4
@@ -93,7 +114,7 @@ size_flags_stretch_ratio = 0.0
 texture = ExtResource("2_w6cn0")
 expand_mode = 5
 
-[node name="ControlName" type="Label" parent="InMargin/ControlsWindow/MoveDown/ButtonTexture"]
+[node name="ControlName" type="Label" parent="OutMargin/InMargin/ControlsWindow/MoveDown/ButtonTexture"]
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
@@ -110,7 +131,7 @@ theme_override_font_sizes/font_size = 56
 text = "S"
 horizontal_alignment = 1
 
-[node name="Hyphen" type="Label" parent="InMargin/ControlsWindow/MoveDown"]
+[node name="Hyphen" type="Label" parent="OutMargin/InMargin/ControlsWindow/MoveDown"]
 custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 size_flags_horizontal = 4
@@ -118,18 +139,18 @@ theme_override_font_sizes/font_size = 56
 text = "-"
 horizontal_alignment = 1
 
-[node name="Description" type="Label" parent="InMargin/ControlsWindow/MoveDown"]
-custom_minimum_size = Vector2(400, 0)
+[node name="Description" type="Label" parent="OutMargin/InMargin/ControlsWindow/MoveDown"]
+custom_minimum_size = Vector2(600, 0)
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_font_sizes/font_size = 36
 text = "Move DOWN"
 
-[node name="MoveLeft" type="HBoxContainer" parent="InMargin/ControlsWindow"]
+[node name="MoveLeft" type="HBoxContainer" parent="OutMargin/InMargin/ControlsWindow"]
 layout_mode = 2
 size_flags_horizontal = 4
 
-[node name="ButtonTexture" type="TextureRect" parent="InMargin/ControlsWindow/MoveLeft"]
+[node name="ButtonTexture" type="TextureRect" parent="OutMargin/InMargin/ControlsWindow/MoveLeft"]
 custom_minimum_size = Vector2(80, 80)
 layout_mode = 2
 size_flags_vertical = 4
@@ -137,7 +158,7 @@ size_flags_stretch_ratio = 0.0
 texture = ExtResource("2_w6cn0")
 expand_mode = 5
 
-[node name="ControlName" type="Label" parent="InMargin/ControlsWindow/MoveLeft/ButtonTexture"]
+[node name="ControlName" type="Label" parent="OutMargin/InMargin/ControlsWindow/MoveLeft/ButtonTexture"]
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
@@ -154,7 +175,7 @@ theme_override_font_sizes/font_size = 56
 text = "A"
 horizontal_alignment = 1
 
-[node name="Hyphen" type="Label" parent="InMargin/ControlsWindow/MoveLeft"]
+[node name="Hyphen" type="Label" parent="OutMargin/InMargin/ControlsWindow/MoveLeft"]
 custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 size_flags_horizontal = 4
@@ -162,18 +183,18 @@ theme_override_font_sizes/font_size = 56
 text = "-"
 horizontal_alignment = 1
 
-[node name="Description" type="Label" parent="InMargin/ControlsWindow/MoveLeft"]
-custom_minimum_size = Vector2(400, 0)
+[node name="Description" type="Label" parent="OutMargin/InMargin/ControlsWindow/MoveLeft"]
+custom_minimum_size = Vector2(600, 0)
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_font_sizes/font_size = 36
 text = "Move LEFT"
 
-[node name="MoveRight" type="HBoxContainer" parent="InMargin/ControlsWindow"]
+[node name="MoveRight" type="HBoxContainer" parent="OutMargin/InMargin/ControlsWindow"]
 layout_mode = 2
 size_flags_horizontal = 4
 
-[node name="ButtonTexture" type="TextureRect" parent="InMargin/ControlsWindow/MoveRight"]
+[node name="ButtonTexture" type="TextureRect" parent="OutMargin/InMargin/ControlsWindow/MoveRight"]
 custom_minimum_size = Vector2(80, 80)
 layout_mode = 2
 size_flags_vertical = 4
@@ -181,7 +202,7 @@ size_flags_stretch_ratio = 0.0
 texture = ExtResource("2_w6cn0")
 expand_mode = 5
 
-[node name="ControlName" type="Label" parent="InMargin/ControlsWindow/MoveRight/ButtonTexture"]
+[node name="ControlName" type="Label" parent="OutMargin/InMargin/ControlsWindow/MoveRight/ButtonTexture"]
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
@@ -198,7 +219,7 @@ theme_override_font_sizes/font_size = 56
 text = "D"
 horizontal_alignment = 1
 
-[node name="Hyphen" type="Label" parent="InMargin/ControlsWindow/MoveRight"]
+[node name="Hyphen" type="Label" parent="OutMargin/InMargin/ControlsWindow/MoveRight"]
 custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 size_flags_horizontal = 4
@@ -206,18 +227,18 @@ theme_override_font_sizes/font_size = 56
 text = "-"
 horizontal_alignment = 1
 
-[node name="Description" type="Label" parent="InMargin/ControlsWindow/MoveRight"]
-custom_minimum_size = Vector2(400, 0)
+[node name="Description" type="Label" parent="OutMargin/InMargin/ControlsWindow/MoveRight"]
+custom_minimum_size = Vector2(600, 0)
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_font_sizes/font_size = 36
 text = "Move RIGHT"
 
-[node name="Attack" type="HBoxContainer" parent="InMargin/ControlsWindow"]
+[node name="Attack" type="HBoxContainer" parent="OutMargin/InMargin/ControlsWindow"]
 layout_mode = 2
 size_flags_horizontal = 4
 
-[node name="ButtonTexture" type="TextureRect" parent="InMargin/ControlsWindow/Attack"]
+[node name="ButtonTexture" type="TextureRect" parent="OutMargin/InMargin/ControlsWindow/Attack"]
 custom_minimum_size = Vector2(120, 80)
 layout_mode = 2
 size_flags_vertical = 4
@@ -225,7 +246,7 @@ size_flags_stretch_ratio = 0.0
 texture = ExtResource("2_w6cn0")
 expand_mode = 5
 
-[node name="ControlName" type="Label" parent="InMargin/ControlsWindow/Attack/ButtonTexture"]
+[node name="ControlName" type="Label" parent="OutMargin/InMargin/ControlsWindow/Attack/ButtonTexture"]
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
@@ -242,7 +263,7 @@ theme_override_font_sizes/font_size = 56
 text = "LMB"
 horizontal_alignment = 1
 
-[node name="Hyphen" type="Label" parent="InMargin/ControlsWindow/Attack"]
+[node name="Hyphen" type="Label" parent="OutMargin/InMargin/ControlsWindow/Attack"]
 custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 size_flags_horizontal = 4
@@ -250,18 +271,18 @@ theme_override_font_sizes/font_size = 56
 text = "-"
 horizontal_alignment = 1
 
-[node name="Description" type="Label" parent="InMargin/ControlsWindow/Attack"]
-custom_minimum_size = Vector2(400, 0)
+[node name="Description" type="Label" parent="OutMargin/InMargin/ControlsWindow/Attack"]
+custom_minimum_size = Vector2(600, 0)
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_font_sizes/font_size = 36
 text = "Launch projectile"
 
-[node name="Parry" type="HBoxContainer" parent="InMargin/ControlsWindow"]
+[node name="Parry" type="HBoxContainer" parent="OutMargin/InMargin/ControlsWindow"]
 layout_mode = 2
 size_flags_horizontal = 4
 
-[node name="ButtonTexture" type="TextureRect" parent="InMargin/ControlsWindow/Parry"]
+[node name="ButtonTexture" type="TextureRect" parent="OutMargin/InMargin/ControlsWindow/Parry"]
 custom_minimum_size = Vector2(120, 80)
 layout_mode = 2
 size_flags_vertical = 4
@@ -269,7 +290,7 @@ size_flags_stretch_ratio = 0.0
 texture = ExtResource("2_w6cn0")
 expand_mode = 5
 
-[node name="ControlName" type="Label" parent="InMargin/ControlsWindow/Parry/ButtonTexture"]
+[node name="ControlName" type="Label" parent="OutMargin/InMargin/ControlsWindow/Parry/ButtonTexture"]
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
@@ -286,7 +307,7 @@ theme_override_font_sizes/font_size = 56
 text = "RMB"
 horizontal_alignment = 1
 
-[node name="Hyphen" type="Label" parent="InMargin/ControlsWindow/Parry"]
+[node name="Hyphen" type="Label" parent="OutMargin/InMargin/ControlsWindow/Parry"]
 custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 size_flags_horizontal = 4
@@ -294,26 +315,26 @@ theme_override_font_sizes/font_size = 56
 text = "-"
 horizontal_alignment = 1
 
-[node name="Description" type="Label" parent="InMargin/ControlsWindow/Parry"]
-custom_minimum_size = Vector2(400, 0)
+[node name="Description" type="Label" parent="OutMargin/InMargin/ControlsWindow/Parry"]
+custom_minimum_size = Vector2(600, 0)
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_font_sizes/font_size = 36
-text = "Parry projectile or attack"
+text = "Parry projectile or  parryattack"
 
-[node name="DarkControls" type="MarginContainer" parent="InMargin/ControlsWindow"]
+[node name="DarkControls" type="MarginContainer" parent="OutMargin/InMargin/ControlsWindow"]
 layout_mode = 2
 theme_override_constants/margin_top = 30
 theme_override_constants/margin_bottom = 30
 
-[node name="VBoxContainer" type="VBoxContainer" parent="InMargin/ControlsWindow/DarkControls"]
+[node name="VBoxContainer" type="VBoxContainer" parent="OutMargin/InMargin/ControlsWindow/DarkControls"]
 layout_mode = 2
 
-[node name="ActivateDarkKnight" type="HBoxContainer" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer"]
+[node name="ActivateDarkKnight" type="HBoxContainer" parent="OutMargin/InMargin/ControlsWindow/DarkControls/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 4
 
-[node name="ButtonTexture" type="TextureRect" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/ActivateDarkKnight"]
+[node name="ButtonTexture" type="TextureRect" parent="OutMargin/InMargin/ControlsWindow/DarkControls/VBoxContainer/ActivateDarkKnight"]
 modulate = Color(0.815686, 0, 0.819608, 1)
 custom_minimum_size = Vector2(120, 80)
 layout_mode = 2
@@ -322,7 +343,7 @@ size_flags_stretch_ratio = 0.0
 texture = ExtResource("2_w6cn0")
 expand_mode = 5
 
-[node name="ControlName" type="Label" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/ActivateDarkKnight/ButtonTexture"]
+[node name="ControlName" type="Label" parent="OutMargin/InMargin/ControlsWindow/DarkControls/VBoxContainer/ActivateDarkKnight/ButtonTexture"]
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
@@ -339,7 +360,7 @@ theme_override_font_sizes/font_size = 56
 text = "E"
 horizontal_alignment = 1
 
-[node name="Hyphen" type="Label" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/ActivateDarkKnight"]
+[node name="Hyphen" type="Label" parent="OutMargin/InMargin/ControlsWindow/DarkControls/VBoxContainer/ActivateDarkKnight"]
 custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 size_flags_horizontal = 4
@@ -347,18 +368,18 @@ theme_override_font_sizes/font_size = 56
 text = "-"
 horizontal_alignment = 1
 
-[node name="Description" type="Label" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/ActivateDarkKnight"]
+[node name="Description" type="Label" parent="OutMargin/InMargin/ControlsWindow/DarkControls/VBoxContainer/ActivateDarkKnight"]
 custom_minimum_size = Vector2(400, 0)
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_font_sizes/font_size = 36
 text = "Turn into EVIL"
 
-[node name="LeftAttack" type="HBoxContainer" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer"]
+[node name="LeftAttack" type="HBoxContainer" parent="OutMargin/InMargin/ControlsWindow/DarkControls/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 4
 
-[node name="ButtonTexture" type="TextureRect" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/LeftAttack"]
+[node name="ButtonTexture" type="TextureRect" parent="OutMargin/InMargin/ControlsWindow/DarkControls/VBoxContainer/LeftAttack"]
 modulate = Color(0.815686, 0, 0.819608, 1)
 custom_minimum_size = Vector2(120, 80)
 layout_mode = 2
@@ -367,7 +388,7 @@ size_flags_stretch_ratio = 0.0
 texture = ExtResource("2_w6cn0")
 expand_mode = 5
 
-[node name="ControlName" type="Label" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/LeftAttack/ButtonTexture"]
+[node name="ControlName" type="Label" parent="OutMargin/InMargin/ControlsWindow/DarkControls/VBoxContainer/LeftAttack/ButtonTexture"]
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
@@ -384,7 +405,7 @@ theme_override_font_sizes/font_size = 56
 text = "LMB"
 horizontal_alignment = 1
 
-[node name="Hyphen" type="Label" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/LeftAttack"]
+[node name="Hyphen" type="Label" parent="OutMargin/InMargin/ControlsWindow/DarkControls/VBoxContainer/LeftAttack"]
 custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 size_flags_horizontal = 4
@@ -392,18 +413,18 @@ theme_override_font_sizes/font_size = 56
 text = "-"
 horizontal_alignment = 1
 
-[node name="Description" type="Label" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/LeftAttack"]
+[node name="Description" type="Label" parent="OutMargin/InMargin/ControlsWindow/DarkControls/VBoxContainer/LeftAttack"]
 custom_minimum_size = Vector2(400, 0)
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_font_sizes/font_size = 36
 text = "Left Attack"
 
-[node name="RightAttack" type="HBoxContainer" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer"]
+[node name="RightAttack" type="HBoxContainer" parent="OutMargin/InMargin/ControlsWindow/DarkControls/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 4
 
-[node name="ButtonTexture" type="TextureRect" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/RightAttack"]
+[node name="ButtonTexture" type="TextureRect" parent="OutMargin/InMargin/ControlsWindow/DarkControls/VBoxContainer/RightAttack"]
 modulate = Color(0.815686, 0, 0.819608, 1)
 custom_minimum_size = Vector2(120, 80)
 layout_mode = 2
@@ -412,7 +433,7 @@ size_flags_stretch_ratio = 0.0
 texture = ExtResource("2_w6cn0")
 expand_mode = 5
 
-[node name="ControlName" type="Label" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/RightAttack/ButtonTexture"]
+[node name="ControlName" type="Label" parent="OutMargin/InMargin/ControlsWindow/DarkControls/VBoxContainer/RightAttack/ButtonTexture"]
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
@@ -429,7 +450,7 @@ theme_override_font_sizes/font_size = 56
 text = "RMB"
 horizontal_alignment = 1
 
-[node name="Hyphen" type="Label" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/RightAttack"]
+[node name="Hyphen" type="Label" parent="OutMargin/InMargin/ControlsWindow/DarkControls/VBoxContainer/RightAttack"]
 custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 size_flags_horizontal = 4
@@ -437,7 +458,7 @@ theme_override_font_sizes/font_size = 56
 text = "-"
 horizontal_alignment = 1
 
-[node name="Description" type="Label" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/RightAttack"]
+[node name="Description" type="Label" parent="OutMargin/InMargin/ControlsWindow/DarkControls/VBoxContainer/RightAttack"]
 custom_minimum_size = Vector2(400, 0)
 layout_mode = 2
 size_flags_horizontal = 4
@@ -445,21 +466,25 @@ theme_override_font_sizes/font_size = 36
 text = "Right Attack
 "
 
-[node name="BlurDarkControls" type="Panel" parent="InMargin/ControlsWindow/DarkControls"]
+[node name="HideDarkControls" type="Panel" parent="OutMargin/InMargin/ControlsWindow/DarkControls"]
 unique_name_in_owner = true
-material = SubResource("ShaderMaterial_h03g3")
 custom_minimum_size = Vector2(1920, 340)
 layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_6d1jf")
 
-[node name="CloseButton" type="MarginContainer" parent="."]
+[node name="CloseButton" type="MarginContainer" parent="OutMargin"]
 layout_mode = 2
 theme_override_constants/margin_right = 495
 theme_override_constants/margin_bottom = 15
 
-[node name="Close" type="Button" parent="CloseButton"]
+[node name="Close" type="Button" parent="OutMargin/CloseButton"]
 unique_name_in_owner = true
 visibility_layer = 3
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 8
-text = "Close Controls"
+theme_override_font_sizes/font_size = 56
+theme_override_styles/normal = SubResource("StyleBoxFlat_pif12")
+theme_override_styles/hover = SubResource("StyleBoxFlat_pif12")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_w80sp")
+text = "Close"

--- a/scenes/ui/controls_window.tscn
+++ b/scenes/ui/controls_window.tscn
@@ -1,0 +1,465 @@
+[gd_scene load_steps=7 format=3 uid="uid://bgfrb27nvy1ug"]
+
+[ext_resource type="Script" path="res://scenes/ui/controls_window.gd" id="1_6ds06"]
+[ext_resource type="FontFile" uid="uid://beo8lmqouqh0k" path="res://assets/graphic/font/ComicNeue-Bold.ttf" id="1_bv8wj"]
+[ext_resource type="Texture2D" uid="uid://cmq216oemk1ex" path="res://assets/graphic/ui/LightDialogueBox.png" id="2_w6cn0"]
+[ext_resource type="Shader" path="res://shaders/blur.gdshader" id="4_6bmxp"]
+
+[sub_resource type="Theme" id="Theme_uaxhm"]
+Label/font_sizes/font_size = 16
+Label/fonts/font = ExtResource("1_bv8wj")
+TextEdit/font_sizes/font_size = 18
+TextEdit/fonts/font = ExtResource("1_bv8wj")
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_h03g3"]
+shader = ExtResource("4_6bmxp")
+shader_parameter/lod = 5.0
+
+[node name="OutMargin" type="MarginContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 100
+theme_override_constants/margin_top = 100
+theme_override_constants/margin_right = 100
+theme_override_constants/margin_bottom = 100
+script = ExtResource("1_6ds06")
+
+[node name="InMargin" type="MarginContainer" parent="."]
+layout_mode = 2
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 20
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 20
+
+[node name="ControlsWindow" type="VBoxContainer" parent="InMargin"]
+layout_mode = 2
+theme = SubResource("Theme_uaxhm")
+
+[node name="MoveUp" type="HBoxContainer" parent="InMargin/ControlsWindow"]
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="ButtonTexture" type="TextureRect" parent="InMargin/ControlsWindow/MoveUp"]
+custom_minimum_size = Vector2(80, 80)
+layout_mode = 2
+size_flags_vertical = 4
+size_flags_stretch_ratio = 0.0
+texture = ExtResource("2_w6cn0")
+expand_mode = 5
+
+[node name="ControlName" type="Label" parent="InMargin/ControlsWindow/MoveUp/ButtonTexture"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -24.0
+offset_top = -32.0
+offset_right = 23.0
+offset_bottom = 33.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/font_size = 56
+text = "W"
+horizontal_alignment = 1
+
+[node name="Hyphen" type="Label" parent="InMargin/ControlsWindow/MoveUp"]
+custom_minimum_size = Vector2(50, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 56
+text = "-"
+horizontal_alignment = 1
+
+[node name="Description" type="Label" parent="InMargin/ControlsWindow/MoveUp"]
+custom_minimum_size = Vector2(400, 0)
+layout_mode = 2
+theme_override_font_sizes/font_size = 36
+text = "Move UP"
+
+[node name="MoveDown" type="HBoxContainer" parent="InMargin/ControlsWindow"]
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="ButtonTexture" type="TextureRect" parent="InMargin/ControlsWindow/MoveDown"]
+custom_minimum_size = Vector2(80, 80)
+layout_mode = 2
+size_flags_vertical = 4
+size_flags_stretch_ratio = 0.0
+texture = ExtResource("2_w6cn0")
+expand_mode = 5
+
+[node name="ControlName" type="Label" parent="InMargin/ControlsWindow/MoveDown/ButtonTexture"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -24.0
+offset_top = -32.0
+offset_right = 23.0
+offset_bottom = 33.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/font_size = 56
+text = "S"
+horizontal_alignment = 1
+
+[node name="Hyphen" type="Label" parent="InMargin/ControlsWindow/MoveDown"]
+custom_minimum_size = Vector2(50, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 56
+text = "-"
+horizontal_alignment = 1
+
+[node name="Description" type="Label" parent="InMargin/ControlsWindow/MoveDown"]
+custom_minimum_size = Vector2(400, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 36
+text = "Move DOWN"
+
+[node name="MoveLeft" type="HBoxContainer" parent="InMargin/ControlsWindow"]
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="ButtonTexture" type="TextureRect" parent="InMargin/ControlsWindow/MoveLeft"]
+custom_minimum_size = Vector2(80, 80)
+layout_mode = 2
+size_flags_vertical = 4
+size_flags_stretch_ratio = 0.0
+texture = ExtResource("2_w6cn0")
+expand_mode = 5
+
+[node name="ControlName" type="Label" parent="InMargin/ControlsWindow/MoveLeft/ButtonTexture"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -24.0
+offset_top = -32.0
+offset_right = 23.0
+offset_bottom = 33.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/font_size = 56
+text = "A"
+horizontal_alignment = 1
+
+[node name="Hyphen" type="Label" parent="InMargin/ControlsWindow/MoveLeft"]
+custom_minimum_size = Vector2(50, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 56
+text = "-"
+horizontal_alignment = 1
+
+[node name="Description" type="Label" parent="InMargin/ControlsWindow/MoveLeft"]
+custom_minimum_size = Vector2(400, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 36
+text = "Move LEFT"
+
+[node name="MoveRight" type="HBoxContainer" parent="InMargin/ControlsWindow"]
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="ButtonTexture" type="TextureRect" parent="InMargin/ControlsWindow/MoveRight"]
+custom_minimum_size = Vector2(80, 80)
+layout_mode = 2
+size_flags_vertical = 4
+size_flags_stretch_ratio = 0.0
+texture = ExtResource("2_w6cn0")
+expand_mode = 5
+
+[node name="ControlName" type="Label" parent="InMargin/ControlsWindow/MoveRight/ButtonTexture"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -24.0
+offset_top = -32.0
+offset_right = 23.0
+offset_bottom = 33.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/font_size = 56
+text = "D"
+horizontal_alignment = 1
+
+[node name="Hyphen" type="Label" parent="InMargin/ControlsWindow/MoveRight"]
+custom_minimum_size = Vector2(50, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 56
+text = "-"
+horizontal_alignment = 1
+
+[node name="Description" type="Label" parent="InMargin/ControlsWindow/MoveRight"]
+custom_minimum_size = Vector2(400, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 36
+text = "Move RIGHT"
+
+[node name="Attack" type="HBoxContainer" parent="InMargin/ControlsWindow"]
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="ButtonTexture" type="TextureRect" parent="InMargin/ControlsWindow/Attack"]
+custom_minimum_size = Vector2(120, 80)
+layout_mode = 2
+size_flags_vertical = 4
+size_flags_stretch_ratio = 0.0
+texture = ExtResource("2_w6cn0")
+expand_mode = 5
+
+[node name="ControlName" type="Label" parent="InMargin/ControlsWindow/Attack/ButtonTexture"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -24.0
+offset_top = -32.0
+offset_right = 23.0
+offset_bottom = 33.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/font_size = 56
+text = "LMB"
+horizontal_alignment = 1
+
+[node name="Hyphen" type="Label" parent="InMargin/ControlsWindow/Attack"]
+custom_minimum_size = Vector2(50, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 56
+text = "-"
+horizontal_alignment = 1
+
+[node name="Description" type="Label" parent="InMargin/ControlsWindow/Attack"]
+custom_minimum_size = Vector2(400, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 36
+text = "Launch projectile"
+
+[node name="Parry" type="HBoxContainer" parent="InMargin/ControlsWindow"]
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="ButtonTexture" type="TextureRect" parent="InMargin/ControlsWindow/Parry"]
+custom_minimum_size = Vector2(120, 80)
+layout_mode = 2
+size_flags_vertical = 4
+size_flags_stretch_ratio = 0.0
+texture = ExtResource("2_w6cn0")
+expand_mode = 5
+
+[node name="ControlName" type="Label" parent="InMargin/ControlsWindow/Parry/ButtonTexture"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -24.0
+offset_top = -32.0
+offset_right = 23.0
+offset_bottom = 33.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/font_size = 56
+text = "RMB"
+horizontal_alignment = 1
+
+[node name="Hyphen" type="Label" parent="InMargin/ControlsWindow/Parry"]
+custom_minimum_size = Vector2(50, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 56
+text = "-"
+horizontal_alignment = 1
+
+[node name="Description" type="Label" parent="InMargin/ControlsWindow/Parry"]
+custom_minimum_size = Vector2(400, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 36
+text = "Parry projectile or attack"
+
+[node name="DarkControls" type="MarginContainer" parent="InMargin/ControlsWindow"]
+layout_mode = 2
+theme_override_constants/margin_top = 30
+theme_override_constants/margin_bottom = 30
+
+[node name="VBoxContainer" type="VBoxContainer" parent="InMargin/ControlsWindow/DarkControls"]
+layout_mode = 2
+
+[node name="ActivateDarkKnight" type="HBoxContainer" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="ButtonTexture" type="TextureRect" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/ActivateDarkKnight"]
+modulate = Color(0.815686, 0, 0.819608, 1)
+custom_minimum_size = Vector2(120, 80)
+layout_mode = 2
+size_flags_vertical = 4
+size_flags_stretch_ratio = 0.0
+texture = ExtResource("2_w6cn0")
+expand_mode = 5
+
+[node name="ControlName" type="Label" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/ActivateDarkKnight/ButtonTexture"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -24.0
+offset_top = -32.0
+offset_right = 23.0
+offset_bottom = 33.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/font_size = 56
+text = "E"
+horizontal_alignment = 1
+
+[node name="Hyphen" type="Label" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/ActivateDarkKnight"]
+custom_minimum_size = Vector2(50, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 56
+text = "-"
+horizontal_alignment = 1
+
+[node name="Description" type="Label" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/ActivateDarkKnight"]
+custom_minimum_size = Vector2(400, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 36
+text = "Turn into EVIL"
+
+[node name="LeftAttack" type="HBoxContainer" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="ButtonTexture" type="TextureRect" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/LeftAttack"]
+modulate = Color(0.815686, 0, 0.819608, 1)
+custom_minimum_size = Vector2(120, 80)
+layout_mode = 2
+size_flags_vertical = 4
+size_flags_stretch_ratio = 0.0
+texture = ExtResource("2_w6cn0")
+expand_mode = 5
+
+[node name="ControlName" type="Label" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/LeftAttack/ButtonTexture"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -24.0
+offset_top = -32.0
+offset_right = 23.0
+offset_bottom = 33.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/font_size = 56
+text = "LMB"
+horizontal_alignment = 1
+
+[node name="Hyphen" type="Label" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/LeftAttack"]
+custom_minimum_size = Vector2(50, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 56
+text = "-"
+horizontal_alignment = 1
+
+[node name="Description" type="Label" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/LeftAttack"]
+custom_minimum_size = Vector2(400, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 36
+text = "Left Attack"
+
+[node name="RightAttack" type="HBoxContainer" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="ButtonTexture" type="TextureRect" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/RightAttack"]
+modulate = Color(0.815686, 0, 0.819608, 1)
+custom_minimum_size = Vector2(120, 80)
+layout_mode = 2
+size_flags_vertical = 4
+size_flags_stretch_ratio = 0.0
+texture = ExtResource("2_w6cn0")
+expand_mode = 5
+
+[node name="ControlName" type="Label" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/RightAttack/ButtonTexture"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -24.0
+offset_top = -32.0
+offset_right = 23.0
+offset_bottom = 33.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/font_size = 56
+text = "RMB"
+horizontal_alignment = 1
+
+[node name="Hyphen" type="Label" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/RightAttack"]
+custom_minimum_size = Vector2(50, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 56
+text = "-"
+horizontal_alignment = 1
+
+[node name="Description" type="Label" parent="InMargin/ControlsWindow/DarkControls/VBoxContainer/RightAttack"]
+custom_minimum_size = Vector2(400, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 36
+text = "Right Attack
+"
+
+[node name="BlurDarkControls" type="Panel" parent="InMargin/ControlsWindow/DarkControls"]
+unique_name_in_owner = true
+material = SubResource("ShaderMaterial_h03g3")
+custom_minimum_size = Vector2(1920, 340)
+layout_mode = 2
+
+[node name="CloseButton" type="MarginContainer" parent="."]
+layout_mode = 2
+theme_override_constants/margin_right = 495
+theme_override_constants/margin_bottom = 15
+
+[node name="Close" type="Button" parent="CloseButton"]
+unique_name_in_owner = true
+visibility_layer = 3
+layout_mode = 2
+size_flags_horizontal = 8
+size_flags_vertical = 8
+text = "Close Controls"

--- a/scenes/ui/pause_hud.gd
+++ b/scenes/ui/pause_hud.gd
@@ -1,16 +1,29 @@
 extends CanvasLayer
 
 
-@onready var continue_button: Button = $HSplitContainer/OptionList/ContinueButton
+@onready var _continue_button: Button = %ContinueButton
+@onready var _controls_button: Button = %ControlsWindowButton
+@onready var _exit_button: Button =  %Exit
+@onready var _controls_pc: PackedScene = preload("res://scenes/ui/controls_window.tscn")
+var _click_sound: AudioStreamPlayer
 
 func _ready() -> void:
-	if continue_button.pressed.connect(_on_continue_pressed): printerr("Fail: ",get_stack()) 
+	if _controls_button.connect("pressed", _on_pressed_controls_window_button): printerr("Fail: ",get_stack()) 
+	if _continue_button.pressed.connect(_on_continue_pressed): printerr("Fail: ",get_stack())
+	if _exit_button.pressed.connect(_on_exit_pressed): printerr("Fail: ",get_stack()) 
 	get_tree().paused = true
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(_delta: float) -> void:
-	pass
-
 func _on_continue_pressed()->void:
+	BossRushUtility.play_click_sound()
 	get_tree().paused = false
 	queue_free()
+
+func _on_pressed_controls_window_button()->void:
+	BossRushUtility.play_click_sound()
+	var controls_window: CanvasItem = _controls_pc.instantiate() as CanvasItem
+	controls_window.z_index = 2
+	$".".add_child(controls_window)
+
+func _on_exit_pressed()->void:
+	BossRushUtility.play_click_sound()
+	get_tree().quit()

--- a/scenes/ui/pause_hud.tscn
+++ b/scenes/ui/pause_hud.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=6 format=3 uid="uid://c1urffu8ljxmj"]
+[gd_scene load_steps=9 format=3 uid="uid://c1urffu8ljxmj"]
 
 [ext_resource type="Script" path="res://scenes/ui/pause_hud.gd" id="1_bsmxl"]
 [ext_resource type="PackedScene" uid="uid://cl6ujwlw4p48c" path="res://scenes/ui/sound_settings.tscn" id="2_mvtu0"]
 [ext_resource type="Shader" path="res://shaders/blur.gdshader" id="2_s4nse"]
+[ext_resource type="FontFile" uid="uid://beo8lmqouqh0k" path="res://assets/graphic/font/ComicNeue-Bold.ttf" id="4_xer5s"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_wam7m"]
 shader = ExtResource("2_s4nse")
@@ -10,6 +11,22 @@ shader_parameter/lod = 1.81
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_2x4d6"]
 bg_color = Color(0.6, 0.6, 0.6, 0)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_pif12"]
+bg_color = Color(0.121569, 0.619608, 0.254902, 1)
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color(0.921569, 0.913725, 0.913725, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_w80sp"]
+bg_color = Color(0.121569, 0.619608, 0.254902, 1)
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color(0.921569, 0.913725, 0.913725, 1)
 
 [node name="PauseHud" type="CanvasLayer"]
 process_mode = 2
@@ -50,11 +67,48 @@ size_flags_horizontal = 3
 
 [node name="OptionList" type="VBoxContainer" parent="HSplitContainer"]
 layout_mode = 2
-size_flags_horizontal = 3
+size_flags_vertical = 4
 
 [node name="ContinueButton" type="Button" parent="HSplitContainer/OptionList"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 6
+theme_override_fonts/font = ExtResource("4_xer5s")
 theme_override_font_sizes/font_size = 64
+theme_override_styles/normal = SubResource("StyleBoxFlat_pif12")
+theme_override_styles/hover = SubResource("StyleBoxFlat_pif12")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_w80sp")
 text = "Continue"
+
+[node name="Space" type="Control" parent="HSplitContainer/OptionList"]
+custom_minimum_size = Vector2(0, 50)
+layout_mode = 2
+
+[node name="ControlsWindowButton" type="Button" parent="HSplitContainer/OptionList"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 6
+theme_override_fonts/font = ExtResource("4_xer5s")
+theme_override_font_sizes/font_size = 64
+theme_override_styles/normal = SubResource("StyleBoxFlat_pif12")
+theme_override_styles/hover = SubResource("StyleBoxFlat_pif12")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_w80sp")
+text = "Controls"
+
+[node name="Space2" type="Control" parent="HSplitContainer/OptionList"]
+custom_minimum_size = Vector2(0, 50)
+layout_mode = 2
+
+[node name="Exit" type="Button" parent="HSplitContainer/OptionList"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 6
+theme_override_fonts/font = ExtResource("4_xer5s")
+theme_override_font_sizes/font_size = 64
+theme_override_styles/normal = SubResource("StyleBoxFlat_pif12")
+theme_override_styles/hover = SubResource("StyleBoxFlat_pif12")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_w80sp")
+text = "Exit"

--- a/scenes/utilities/loading_screen/loading_screen.gd
+++ b/scenes/utilities/loading_screen/loading_screen.gd
@@ -24,4 +24,5 @@ func finish_transition() -> void:
 		ending_animation_name = "fade_from_black"
 	anim_player.play(ending_animation_name)
 	await anim_player.animation_finished
+	get_tree().paused = false
 	queue_free()

--- a/scenes/utilities/loading_screen/loading_screen.tscn
+++ b/scenes/utilities/loading_screen/loading_screen.tscn
@@ -57,6 +57,7 @@ _data = {
 }
 
 [node name="LoadingScreen" type="CanvasLayer"]
+process_mode = 3
 layer = 2
 script = ExtResource("1_bcyoi")
 

--- a/scripts/autoload/boss_rush_utility.gd
+++ b/scripts/autoload/boss_rush_utility.gd
@@ -1,0 +1,18 @@
+extends Node
+
+@onready var _controls_window: PackedScene = preload("res://scenes/ui/controls_window.tscn")
+var _click_sound: AudioStreamPlayer
+
+func _ready() -> void:
+	_click_sound = AudioStreamPlayer.new()
+	add_child(_click_sound)
+	_click_sound.bus = "SFX"
+	_click_sound.stream = load("res://assets/audio/sfx/click.wav")
+
+func show_opened_abilities()->void:
+	var controls_window: ControlsWindow = _controls_window.instantiate()
+	controls_window.start_animation = true
+	add_child(controls_window)
+
+func play_click_sound()->void:
+	_click_sound.play()

--- a/scripts/autoload/level_manager.gd
+++ b/scripts/autoload/level_manager.gd
@@ -25,9 +25,8 @@ func _end_load_level()-> void:
 	var _new_level_node: Node = _level_scene.instantiate()
 	add_sibling(_new_level_node,true)
 	get_tree().current_scene = _new_level_node
-	print(get_tree().current_scene.name)
-	await loading_screen.finish_transition()
 	if emit_signal("transition_finished"): printerr("Fail: ",get_stack()) 
+	await loading_screen.finish_transition()
 
 func _on_transition_in_ended()->void:
 	get_tree().current_scene.queue_free()

--- a/scripts/autoload/story_state.gd
+++ b/scripts/autoload/story_state.gd
@@ -1,3 +1,8 @@
 extends Node
 
-var agreed_with_the_helmet: bool = false
+signal player_got_ability
+
+var is_player_has_dark_ability: bool = false:
+	set(value):
+		player_got_ability.emit()
+		is_player_has_dark_ability = value


### PR DESCRIPTION
PC actions and player controls window
Removd debug prints in AI
Dialogue pops up controls If player agree with the offer
Dialogue enhacements:
    1)Dialogue baloon changes background according to the speaker and same with the sound
    2)Make unable to process player scene and turn off AI's brain when dialogue is active
Add global function in utility global script to play sound ( temporary solution )
Remove AI before intro dialogue in the first boss fight
Add third level with magic helmet dialogue
Remove blur effect in controls window because of unconvinient draw order.
Add controls and exit buttons in pause_hud
Add global script "boss_rush_utility" to speed up the development ( temporary solution )